### PR TITLE
fix: filter out closed PRs

### DIFF
--- a/src/is-commit-in-filtered-prs.ts
+++ b/src/is-commit-in-filtered-prs.ts
@@ -23,9 +23,9 @@ export default function isCommitInFilteredPRs(
 
   core.info(`Commit in PRs (pre-filtering): ${getPrsIdsString(pullRequests)}`)
 
-  const filteredPRs = pullRequests.filter(
-    ({draft}) => !draft || !!options.includeDraft
-  )
+  const filteredPRs = pullRequests
+    .filter(({state}) => state === 'open')
+    .filter(({draft}) => !draft || !!options.includeDraft)
 
   core.info(`Commit in PRs (post-filtering): ${getPrsIdsString(filteredPRs)}`)
 

--- a/tests/create-dummy-pr.ts
+++ b/tests/create-dummy-pr.ts
@@ -2,12 +2,14 @@ import {PR} from '../src/types/pull-request'
 
 interface Options {
   sha?: string
+  closed?: boolean
   draft?: boolean
 }
 
 export default function createDummyPR(id: number, options: Options): PR {
   return {
     number: id,
+    state: options.closed ? 'closed' : 'open',
     draft: options.draft ?? false,
     head: {
       sha: options.sha ?? ''

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -17,3 +17,10 @@ test('filter out draft PRs', () => {
   const foundPR = isCommitInFilteredPRs(testPRs, {includeDraft: false})
   expect(foundPR).toBe(false)
 })
+
+test('filter out closed PRs', () => {
+  const testPRs = [createDummyPR(1, {closed: true})]
+
+  const foundPR = isCommitInFilteredPRs(testPRs, {includeDraft: false})
+  expect(foundPR).toBe(false)
+})


### PR DESCRIPTION
I accidentally removed the closed PR filtering. This adds a test case and restores it.

Fixes #3.